### PR TITLE
feat: initialize entities

### DIFF
--- a/src/main/java/com/coding/yo/entity/Comment.java
+++ b/src/main/java/com/coding/yo/entity/Comment.java
@@ -33,11 +33,11 @@ public class Comment {
     @Column(columnDefinition = "boolean default false")
     private Boolean blocked;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/coding/yo/entity/Comment.java
+++ b/src/main/java/com/coding/yo/entity/Comment.java
@@ -6,21 +6,17 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
-import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "post")
-public class Post {
+@Table(name = "comment")
+public class Comment {
 
     @Id
-    @Column(name = "post_id")
+    @Column(name = "comment_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(nullable = false, length = 50)
-    private String title;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
@@ -37,25 +33,20 @@ public class Post {
     @Column(columnDefinition = "boolean default false")
     private Boolean blocked;
 
-    @Column(name = "video_id", nullable = false, length = 20)
-    private String videoId;
-
-    @Embedded
-    private TimeColumns timeColumns;
-
-    @OneToMany(mappedBy = "post")
-    private Set<Tag> tags;
-
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PostReport> postReports;
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PostLike> postLikes;
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Comment> comments;
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<CommentReport> commentReports;
+
+    @Embedded
+    private TimeColumns timeColumns;
 }

--- a/src/main/java/com/coding/yo/entity/Comment.java
+++ b/src/main/java/com/coding/yo/entity/Comment.java
@@ -3,6 +3,7 @@ package com.coding.yo.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.util.List;
@@ -24,13 +25,15 @@ public class Comment {
     @Column(nullable = false, length = 50)
     private String creator;
 
-    @Column(name = "like_count", columnDefinition = "integer default 0")
+    @Column(name = "like_count")
+    @ColumnDefault("0")
     private Integer likeCount;
 
-    @Column(name = "report_count", columnDefinition = "integer default 0")
+    @Column(name = "report_count")
+    @ColumnDefault("0")
     private Integer reportCount;
 
-    @Column(columnDefinition = "boolean default false")
+    @ColumnDefault("false")
     private Boolean blocked;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/coding/yo/entity/CommentLike.java
+++ b/src/main/java/com/coding/yo/entity/CommentLike.java
@@ -18,11 +18,11 @@ public class CommentLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/coding/yo/entity/CommentLike.java
+++ b/src/main/java/com/coding/yo/entity/CommentLike.java
@@ -1,0 +1,31 @@
+package com.coding.yo.entity;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comment_like")
+public class CommentLike {
+
+    @Id
+    @Column(name = "comment_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Embedded
+    private TimeColumns timeColumns;
+}

--- a/src/main/java/com/coding/yo/entity/CommentReport.java
+++ b/src/main/java/com/coding/yo/entity/CommentReport.java
@@ -1,0 +1,30 @@
+package com.coding.yo.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comment_report")
+public class CommentReport {
+
+    @Id
+    @Column(name = "comment_report_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Embedded
+    private TimeColumns timeColumns;
+}

--- a/src/main/java/com/coding/yo/entity/CommentReport.java
+++ b/src/main/java/com/coding/yo/entity/CommentReport.java
@@ -17,11 +17,11 @@ public class CommentReport {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/coding/yo/entity/Member.java
+++ b/src/main/java/com/coding/yo/entity/Member.java
@@ -1,0 +1,49 @@
+package com.coding.yo.entity;
+
+import com.coding.yo.util.Role;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "member")
+public class Member {
+
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false, length = 10)
+    private String username;
+
+    @Column(name = "profile_url", nullable = false)
+    private String profileUrl;
+
+    @Column(name = "user_role", columnDefinition = "varchar(10) default 'USER'")
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Post> post;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<CommentReport> commentReports;
+
+    @Embedded
+    private TimeColumns timeColumns;
+}

--- a/src/main/java/com/coding/yo/entity/Post.java
+++ b/src/main/java/com/coding/yo/entity/Post.java
@@ -3,6 +3,7 @@ package com.coding.yo.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.util.List;
@@ -28,13 +29,15 @@ public class Post {
     @Column(nullable = false, length = 50)
     private String creator;
 
-    @Column(name = "like_count", columnDefinition = "integer default 0")
+    @Column(name = "like_count")
+    @ColumnDefault("0")
     private Integer likeCount;
 
-    @Column(name = "report_count", columnDefinition = "integer default 0")
+    @Column(name = "report_count")
+    @ColumnDefault("0")
     private Integer reportCount;
 
-    @Column(columnDefinition = "boolean default false")
+    @ColumnDefault("false")
     private Boolean blocked;
 
     @Column(name = "video_id", nullable = false, length = 20)

--- a/src/main/java/com/coding/yo/entity/Post.java
+++ b/src/main/java/com/coding/yo/entity/Post.java
@@ -46,7 +46,7 @@ public class Post {
     @OneToMany(mappedBy = "post")
     private Set<Tag> tags;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/coding/yo/entity/PostLike.java
+++ b/src/main/java/com/coding/yo/entity/PostLike.java
@@ -1,0 +1,30 @@
+package com.coding.yo.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "post_like")
+public class PostLike {
+
+    @Id
+    @Column(name = "post_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Embedded
+    private TimeColumns timeColumns;
+}

--- a/src/main/java/com/coding/yo/entity/PostLike.java
+++ b/src/main/java/com/coding/yo/entity/PostLike.java
@@ -17,11 +17,11 @@ public class PostLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/coding/yo/entity/PostReport.java
+++ b/src/main/java/com/coding/yo/entity/PostReport.java
@@ -16,11 +16,11 @@ public class PostReport {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/coding/yo/entity/PostReport.java
+++ b/src/main/java/com/coding/yo/entity/PostReport.java
@@ -1,0 +1,29 @@
+package com.coding.yo.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "post_report")
+public class PostReport {
+    @Id
+    @Column(name = "post_report_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Embedded
+    private TimeColumns timeColumns;
+}

--- a/src/main/java/com/coding/yo/entity/Tag.java
+++ b/src/main/java/com/coding/yo/entity/Tag.java
@@ -1,0 +1,26 @@
+package com.coding.yo.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tag")
+public class Tag {
+
+    @Id
+    @Column(name = "tag_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "tag_name", nullable = false, length = 10)
+    private String tagName;
+}

--- a/src/main/java/com/coding/yo/entity/Tag.java
+++ b/src/main/java/com/coding/yo/entity/Tag.java
@@ -17,7 +17,7 @@ public class Tag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/coding/yo/entity/TimeColumns.java
+++ b/src/main/java/com/coding/yo/entity/TimeColumns.java
@@ -1,0 +1,14 @@
+package com.coding.yo.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.time.OffsetDateTime;
+
+@Embeddable
+public class TimeColumns {
+    @Column(name = "created_at", columnDefinition = "timestamp with time zone default current_timestamp")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "timestamp with time zone default current_timestamp")
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/coding/yo/util/Role.java
+++ b/src/main/java/com/coding/yo/util/Role.java
@@ -1,0 +1,5 @@
+package com.coding.yo.util;
+
+public enum Role {
+    USER, ADMIN
+}


### PR DESCRIPTION
JPA 초기화 코드를 작성하였습니다.

1. PostgreSQL 의 경우 user 를 예약어로 인식하는 것 같습니다. 그래서 user 테이블을 member 라는 이름으로 바꿨습니다.
2. 사실 user 의 role property 는 PostgreSQL 의 경우 다른 방식으로 enum 을 선언해야 하는데 (hibernate-types 활용) 일단은 너무 지체되는 것 같아서 PR 을 올렸습니다.
3. application.yml 같은 보안 정보가 담긴 파일은 통상적으로 외부 레포지토리에 올리지 않는 것으로 알고 있습니다. 그래서 이 부분은 나중에 따로 슬랙으로 보내드리겠습니다.